### PR TITLE
Increased register width.

### DIFF
--- a/hdl/jpegenc_v1/verilog/RLE.v
+++ b/hdl/jpegenc_v1/verilog/RLE.v
@@ -105,8 +105,8 @@ module rle
    reg 			       dovalid_reg = 1'b0;
    reg [5:0] 		       zero_cnt = 0;
     
-   reg [5:0] 		       wr_cnt_d1 = 0;
-   reg [5:0] 		       wr_cnt = 0;
+   reg [6:0] 		       wr_cnt_d1 = 0;
+   reg [6:0] 		       wr_cnt = 0;
    reg [5:0] 		       rd_cnt = 0;
    reg 			       rd_en = 1'b0;
     


### PR DESCRIPTION
The `wr_cnt` and `wr_cnt_d1` variables runs from 0 till 64 as per the `VHDL` design. As we have used only 6 bit register the value 64 is shown as Zero.

The above PR is regarding increase in Register Width to 7 bits.