### PR TITLE
Testing infrastructure skip if simulators not available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,8 @@ install:
 
 script:
    - cd test
-   - coverage run --source=jpegenc -m py.test --include-reference
+   - coverage run --source=jpegenc -m py.test --sim=ghdl 
+   - coverage run --source=jpegenc -m py.test --sim=iverilog
    - cp .coverage ../
 
 after_success:

--- a/jpegenc/testing/testing.py
+++ b/jpegenc/testing/testing.py
@@ -1,4 +1,4 @@
-
+import py
 import sys
 import os
 import subprocess
@@ -16,10 +16,7 @@ if hasattr(sys, '_called_from_test'):
 
 def sim_available(sim='ghdl'):
     ok = True
-    version = '-V' if sim == 'iverilog' else '-v'
-    try:
-        subprocess.call([sim, version])
-    except FileNotFoundError as err:
+    if not py.path.local.sysfind(sim):
         ok = False
     return ok
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,15 +1,40 @@
-
 import sys
 
+import py
+import pytest
+
+from myhdl.conversion import analyze, verify
+from myhdl.conversion._verify import _simulators
+
+xfail = pytest.mark.xfail
+
+all_sims = list(_simulators)
+
+if sys.version_info[0] > 2:
+    collect_ignore = ['conversion/toVerilog/test_not_supported_py2.py']
 
 def pytest_addoption(parser):
-    parser.addoption("--include-reference", action="store_true",
-                     help="Include the reference design cosim tests")
+    parser.addoption("--sim", action="store", choices=all_sims,
+                     help="HDL Simulator")
 
 
 def pytest_configure(config):
-    sys._called_from_test = True
+    sim = config.getoption('sim')
+    if sim is not None:
+        verify.simulator = analyze.simulator = sim
+
+def pytest_report_header(config):
+    sim = config.getoption('sim')
+    if config.getoption('sim') is not None:
+        hdr = ['Simulator: {sim}']
+        if not py.path.local.sysfind(sim):
+            hdr += ['Warning: {sim} not found in PATH']
+        return '\n'.join(hdr).format(sim=sim)
 
 
-def pytest_unconfigure(config):
-    del sys._called_from_test
+def bug(issue_no, hdl='all'):
+    if hdl == 'all':
+        sims = all_sims
+    else:
+        sims = [k for k, v in _simulators.items() if v.hdl.lower() == hdl]
+    return xfail(verify.simulator in sims, reason='issue '+issue_no)

--- a/test/test_dct_1d.py
+++ b/test/test_dct_1d.py
@@ -14,7 +14,9 @@ from jpegenc.subblocks.dct.dct_1d import dct_1d_transformation
 from jpegenc.testing import sim_available, run_testbench
 from jpegenc.testing import clock_driver, reset_on_start, pulse_reset
 
-simsok = sim_available('iverilog') and sim_available('ghdl')
+simsok = sim_available('ghdl')
+"""default simulator"""
+verify.simulator = "ghdl"
 
 
 class InputsAndOutputs(object):
@@ -166,13 +168,7 @@ def test_dct_1d_conversion():
 
         return tdut, tbclk, tbstim, monitor, tbrst, print_assign
 
-    # verify and convert with GHDL
-    verify.simulator = 'ghdl'
     assert bench_dct_1d().verify_convert() == 0
-    # verify and convert with iverilog
-    verify.simulator = 'iverilog'
-    assert bench_dct_1d().verify_convert() == 0
-
 
 if __name__ == '__main__':
     test_dct_1d()

--- a/test/test_dct_2d.py
+++ b/test/test_dct_2d.py
@@ -18,7 +18,9 @@ from jpegenc.subblocks.dct.dct_2d import dct_2d_transformation
 from jpegenc.testing import sim_available, run_testbench
 from jpegenc.testing import clock_driver, reset_on_start, pulse_reset
 
-simsok = sim_available('ghdl') and sim_available('iverilog')
+simsok = sim_available('ghdl')
+"""default simulator"""
+verify.simulator = "ghdl"
 
 
 class InputsAndOutputs(object):
@@ -184,13 +186,7 @@ def test_dct_2d_conversion():
 
         return tdut, tbclk, tbstim, monitor, tbrst, print_assign
 
-    # verify and convert with GHDL
-    verify.simulator = 'ghdl'
     assert bench_dct_2d().verify_convert() == 0
-    # verify and convert with iverilog
-    verify.simulator = 'iverilog'
-    assert bench_dct_2d().verify_convert() == 0
-
 
 if __name__ == '__main__':
     test_dct_2d()

--- a/test/test_frontend.py
+++ b/test/test_frontend.py
@@ -18,7 +18,9 @@ from jpegenc.subblocks.frontend import frontend_top_level, frontend_transform
 from jpegenc.testing import sim_available, run_testbench
 from jpegenc.testing import clock_driver, reset_on_start, pulse_reset
 
-simsok = sim_available('ghdl') and sim_available('iverilog')
+simsok = sim_available('ghdl')
+"""default simulator"""
+verify.simulator = "ghdl"
 
 class InputsAndOutputs(object):
 
@@ -131,6 +133,7 @@ def test_frontend():
 
     run_testbench(bench_frontend)
 
+@pytest.mark.skipif(not simsok, reason="missing installed simulator")
 def test_frontend_conversion():
 
     samples, N = 1, 8
@@ -153,6 +156,7 @@ def test_frontend_conversion():
 
         tdut = frontend_top_level(inputs, outputs, clock, reset)
         tbclock = clock_driver(clock)
+        tbrst = reset_on_start(reset, clock)
 
         print_sig_y = [Signal(intbv(0, min=-2**output_bits, max=2**output_bits))
                      for _ in range(N**2)]
@@ -169,7 +173,7 @@ def test_frontend_conversion():
 
         @instance
         def tbstim():
-            yield pulse_reset(reset, clock)
+            yield reset.negedge
             inputs.data_valid.next = True
 
             for i in range(samples):
@@ -225,9 +229,9 @@ def test_frontend_conversion():
                     outputs_count += 1
             raise StopSimulation
 
-        return tdut, tbclock, tbstim, monitor, print_assign
+        return tdut, tbclock, tbstim, monitor, print_assign, tbrst
 
-    run_testbench(bench_frontend)
+    assert bench_frontend().verify_convert() == 0
 
 if __name__ == '__main__':
     test_frontend()

--- a/test/test_rgb2ycbcr.py
+++ b/test/test_rgb2ycbcr.py
@@ -11,7 +11,9 @@ from jpegenc.subblocks.common import RGB, YCbCr
 from jpegenc.testing import sim_available, run_testbench
 from jpegenc.testing import clock_driver, reset_on_start, pulse_reset
 
-simsok = sim_available('iverilog') and sim_available('ghdl')
+simsok = sim_available('ghdl')
+"""default simulator"""
+verify.simulator = "ghdl"
 
 
 def print_results(inputs, expected_outputs, actual_outputs):
@@ -179,9 +181,4 @@ def test_block_conversion():
 
         return tbdut, tbclk, tbstim, tbrst
 
-    # verify and convert with iverilog
-    verify.simulator = 'iverilog'
-    assert bench_color_trans().verify_convert() == 0
-    # verify and convert with GHDL
-    verify.simulator = 'ghdl'
     assert bench_color_trans().verify_convert() == 0

--- a/test/test_zig_zag.py
+++ b/test/test_zig_zag.py
@@ -16,7 +16,9 @@ from jpegenc.testing import clock_driver, reset_on_start, pulse_reset
 
 from random import randrange
 
-simsok = sim_available('ghdl') and sim_available('iverilog')
+simsok = sim_available('ghdl')
+"""default simulator"""
+verify.simulator = "ghdl"
 
 class InputsAndOutputs(object):
 
@@ -160,11 +162,6 @@ def test_zig_zag_conversion():
 
         return tdut, tbclock, tbstim, monitor, print_assign, input_assign
 
-    # verify and convert with GHDL
-    verify.simulator = 'ghdl'
-    assert bench_zig_zag().verify_convert() == 0
-    # verify and convert with iverilog
-    verify.simulator = 'iverilog'
     assert bench_zig_zag().verify_convert() == 0
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added --sim option for the tests. Also the default is "ghdl". travis.yml changed to run the test with ghdl and iverilog. if the ghdl simulator is not installed then the conversion test is passed.
@cfelton 